### PR TITLE
Configure which network interface to use for tests

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -3,9 +3,25 @@ import sys
 import getopt
 import ConfigParser
 import logging
+import socket
+import fcntl
+import struct
+import httplib
 
 from probe import OrgProbe
 from api import APIRequest
+
+def get_ip_address(ifname):
+    # Return the IP address for a given interface name
+
+    # Create a new socket object using IPv4 address family and UDP protocol
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(                # Return the unpacked dotted-quad notation of...
+        fcntl.ioctl(                        # the results of a system ioctl call that...
+        s.fileno(),                         # using the file descriptor of the socket created above...
+        0x8915,                             # calls the C function SIOCGIFADDR to get an interface address...
+        struct.pack('256s', ifname[:15])    # passing to it the interface name, truncated to 15 characters, packed into single 256-byte string.
+        )[20:24])                           # Limit what is returned to just those bytes from the response in which the IP address is contained.
 
 optlist, optargs = getopt.getopt(sys.argv[1:],
 	'c:v',
@@ -30,6 +46,22 @@ if not config.has_section('global'):
 	config.set('global','interval',1)
 	with open(configfile,'w') as fp:
 		config.write(fp)
+
+try:
+    iface = config.get('global','interface')
+    sourceIP = get_ip_address(iface)
+
+    # Monkey patch httplib to make it source-address aware
+    HTTPSConnection_real = httplib.HTTPSConnection
+    class HTTPSConnection_monkey(HTTPSConnection_real):
+        def __init__(*a, **kw):
+            HTTPSConnection_real.__init__(*a, source_address=(sourceIP, 0), **kw)
+    httplib.HTTPSConnection = HTTPSConnection_monkey
+    logging.info("Using network interface %s (%s)", iface, sourceIP)
+except ConfigParser.NoOptionError:
+    logging.info("Network interface not configured - using system default")
+except IOError:
+    logging.info("Configured network interface " + iface + " does not exist - using system default")
 
 if config.has_section('api'):
 	def apiconfig(prop, method):

--- a/config.ini.example
+++ b/config.ini.example
@@ -2,6 +2,11 @@
 # sleep between tests
 interval = 1  
 
+# Add "interface" to use a specific network interface for testing
+# interface = ppp0
+# interface = wlan0
+# interface = eth0
+
 [api]
 # API address details
 host=api.bowdlerize.co.uk


### PR DESCRIPTION
- Add interface option to config file
- Add function to look up IP address of an interface from its name
- If interface option is specified, monkey patch httplib so that we can
  pass it a source IP address to which it can bind, and then pass it the
  IP address of the interface named in the config file.
